### PR TITLE
Add notes in loopy

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -19,3 +19,27 @@ catcher <- function(expr) {
 is_failure <- function(x) {
   inherits(x, "try-error")
 }
+
+has_log_notes <- function(x) {
+  is_failure(x)
+  #"notes" %in% names(attributes(x))
+}
+
+append_log_notes <- function(notes, x, location) {
+  if (is_failure(x)) {
+    note <- attr(x, "condition")$message
+  } else {
+    note <- attr(x, "notes")
+  }
+  tibble::add_row(
+    notes, 
+    location = location,
+    type = "error",
+    note = note
+  )
+}
+
+remove_log_notes <- function(x) {
+  attr(x, "notes") <- NULL
+  x
+}

--- a/R/tune_grid_loop_new.R
+++ b/R/tune_grid_loop_new.R
@@ -88,9 +88,6 @@ tune_grid_loop_new <- function(
 			dplyr::full_join(resamples, by = id_cols)
 	}
 
-	# TODO faking notes
-	res$.notes <- purrr::map(1:nrow(res), ~tibble::tibble())
-
 	res <- res %>%
 		dplyr::relocate(
 			splits,

--- a/tests/testthat/_snaps/loopy-logging.md
+++ b/tests/testthat/_snaps/loopy-logging.md
@@ -1,0 +1,9 @@
+# doesn't capturing message in notes
+
+    Code
+      res_fit <- tune_grid(wf_spec, folds, grid = 2, control = control_grid(
+        allow_par = FALSE))
+    Message
+      testing message
+      testing message
+

--- a/tests/testthat/_snaps/loopy-logging.md
+++ b/tests/testthat/_snaps/loopy-logging.md
@@ -1,7 +1,7 @@
 # doesn't capturing message in notes
 
     Code
-      res_fit <- tune_grid(wf_spec, folds, grid = 2, control = control_grid(
+      res_fit <- melodie_grid(wf_spec, folds, grid = 2, control = control_grid(
         allow_par = FALSE))
     Message
       testing message

--- a/tests/testthat/helper-logging.R
+++ b/tests/testthat/helper-logging.R
@@ -1,0 +1,60 @@
+step_logging_helper <-
+  function(
+    recipe,
+    ...,
+    type = NULL,
+    role = "predictor",
+    trained = FALSE,
+    skip = FALSE,
+    id = recipes::rand_id("logging_helper")
+  ) {
+    recipes::add_step(
+      recipe,
+      step_logging_helper_new(
+        terms = rlang::enquos(...),
+        type = type,
+        role = role,
+        trained = trained,
+        skip = skip,
+        id = id
+      )
+    )
+  }
+
+step_logging_helper_new <-
+  function(terms, type, role, trained, skip, id) {
+    recipes::step(
+      subclass = "logging_helper",
+      terms = terms,
+      type = type,
+      role = role,
+      trained = trained,
+      skip = skip,
+      id = id
+    )
+  }
+
+prep.step_logging_helper <- function(x, training, info = NULL, ...) {
+  if (identical(x$type, "error")) {
+    stop("testing error")
+  }
+  if (identical(x$type, "warning")) {
+    warning("testing warning")
+  }
+  if (identical(x$type, "message")) {
+    message("testing message")
+  }
+
+  step_logging_helper_new(
+    terms = x$terms,
+    type = x$type,
+    role = x$role,
+    trained = TRUE,
+    skip = x$skip,
+    id = x$id
+  )
+}
+
+bake.step_logging_helper <- function(object, new_data, ...) {
+  new_data
+}

--- a/tests/testthat/test-loopy-logging.R
+++ b/tests/testthat/test-loopy-logging.R
@@ -9,8 +9,7 @@ test_that("preprocessor error doesn't stop grid", {
   exp <- bind_cols(
     folds,
     tibble(
-      .metrics = list(NULL),
-      .notes = list(tibble())
+      .metrics = list(NULL)
     )
   )
 
@@ -23,10 +22,14 @@ test_that("preprocessor error doesn't stop grid", {
   )
 
   expect_identical(
-    res_fit, 
+    dplyr::select(res_fit, -.notes), 
     exp,
     ignore_attr = TRUE
   )
+
+  expect_identical(nrow(res_fit$.notes[[1]]), 1L)
+  expect_identical(ncol(res_fit$.notes[[1]]), 3L)
+  expect_true(all(vapply(res_fit$.notes[[1]], is.character, logical(1))))
 })
 
 test_that("model error doesn't stop grid", {
@@ -40,8 +43,7 @@ test_that("model error doesn't stop grid", {
   exp <- bind_cols(
     folds,
     tibble(
-      .metrics = list(NULL),
-      .notes = list(tibble())
+      .metrics = list(NULL)
     )
   )
 
@@ -49,7 +51,7 @@ test_that("model error doesn't stop grid", {
   mod_spec <- parsnip::nearest_neighbor("regression", "kknn", dist_power = tune())
 
   wf_spec <- workflow(rec_spec, mod_spec)
-  
+
   res_fit <- melodie_grid(
     wf_spec,
     folds,
@@ -58,10 +60,14 @@ test_that("model error doesn't stop grid", {
   )
 
   expect_identical(
-    res_fit, 
+    dplyr::select(res_fit, -.notes), 
     exp,
     ignore_attr = TRUE
   )
+
+  expect_identical(nrow(res_fit$.notes[[1]]), 2L)
+  expect_identical(ncol(res_fit$.notes[[1]]), 3L)
+  expect_true(all(vapply(res_fit$.notes[[1]], is.character, logical(1))))
 })
 
 test_that("prediction error doesn't stop grid", {
@@ -78,8 +84,7 @@ test_that("prediction error doesn't stop grid", {
   exp <- bind_cols(
     folds,
     tibble(
-      .metrics = list(NULL),
-      .notes = list(tibble())
+      .metrics = list(NULL)
     )
   )
 
@@ -96,8 +101,12 @@ test_that("prediction error doesn't stop grid", {
   )
 
   expect_identical(
-    res_fit, 
+    dplyr::select(res_fit, -.notes), 
     exp,
     ignore_attr = TRUE
   )
+
+  expect_identical(nrow(res_fit$.notes[[1]]), 2L)
+  expect_identical(ncol(res_fit$.notes[[1]]), 3L)
+  expect_true(all(vapply(res_fit$.notes[[1]], is.character, logical(1))))
 })

--- a/tests/testthat/test-loopy-logging.R
+++ b/tests/testthat/test-loopy-logging.R
@@ -22,7 +22,7 @@ test_that("preprocessor error doesn't stop grid", {
   )
 
   expect_identical(
-    dplyr::select(res_fit, -.notes), 
+    dplyr::select(res_fit, -.notes),
     exp,
     ignore_attr = TRUE
   )
@@ -60,7 +60,7 @@ test_that("model error doesn't stop grid", {
   )
 
   expect_identical(
-    dplyr::select(res_fit, -.notes), 
+    dplyr::select(res_fit, -.notes),
     exp,
     ignore_attr = TRUE
   )
@@ -92,7 +92,7 @@ test_that("prediction error doesn't stop grid", {
   mod_spec <- parsnip::nearest_neighbor("regression", "kknn", dist_power = tune())
 
   wf_spec <- workflow(rec_spec, mod_spec)
-  
+
   res_fit <- melodie_grid(
     wf_spec,
     folds,
@@ -101,7 +101,7 @@ test_that("prediction error doesn't stop grid", {
   )
 
   expect_identical(
-    dplyr::select(res_fit, -.notes), 
+    dplyr::select(res_fit, -.notes),
     exp,
     ignore_attr = TRUE
   )
@@ -154,7 +154,7 @@ test_that("capturing error correctly in notes", {
 test_that("capturing warning correctly in notes", {
   assign("prep.step_logging_helper", prep.step_logging_helper, envir = .GlobalEnv)
   assign("bake.step_logging_helper", bake.step_logging_helper, envir = .GlobalEnv)
-  
+
   ames <- modeldata::ames[, c(72, 40:45)]
 
   set.seed(1234)
@@ -194,7 +194,7 @@ test_that("capturing warning correctly in notes", {
 test_that("doesn't capturing message in notes", {
   assign("prep.step_logging_helper", prep.step_logging_helper, envir = .GlobalEnv)
   assign("bake.step_logging_helper", bake.step_logging_helper, envir = .GlobalEnv)
-  
+
   ames <- modeldata::ames[, c(72, 40:45)]
 
   set.seed(1234)
@@ -211,7 +211,7 @@ test_that("doesn't capturing message in notes", {
   wf_spec <- workflow(rec_spec, mod_spec)
 
   expect_snapshot(
-    res_fit <- tune_grid(
+    res_fit <- melodie_grid(
       wf_spec,
       folds,
       grid = 2,
@@ -220,8 +220,8 @@ test_that("doesn't capturing message in notes", {
   )
 
   exp <- tibble::tibble(
-    location = character(0), 
-    type = character(0), 
+    location = character(0),
+    type = character(0),
     note = character(0)
   )
 

--- a/tests/testthat/test-loopy-logging.R
+++ b/tests/testthat/test-loopy-logging.R
@@ -110,3 +110,127 @@ test_that("prediction error doesn't stop grid", {
   expect_identical(ncol(res_fit$.notes[[1]]), 3L)
   expect_true(all(vapply(res_fit$.notes[[1]], is.character, logical(1))))
 })
+
+test_that("capturing error correctly in notes", {
+  assign("prep.step_logging_helper", prep.step_logging_helper, envir = .GlobalEnv)
+  assign("bake.step_logging_helper", bake.step_logging_helper, envir = .GlobalEnv)
+  ames <- modeldata::ames[, c(72, 40:45)]
+
+  set.seed(1234)
+  folds <- rsample::vfold_cv(ames, 2)
+
+  rec_spec <- recipe(Sale_Price ~ ., ames) %>%
+    step_logging_helper(type = "error")
+  mod_spec <- parsnip::nearest_neighbor(
+    "regression",
+    "kknn",
+    dist_power = tune()
+  )
+
+  wf_spec <- workflow(rec_spec, mod_spec)
+
+  res_fit <- melodie_grid(
+    wf_spec,
+    folds,
+    grid = 2,
+    control = control_grid(allow_par = FALSE)
+  )
+
+  exp <- tibble::tibble(
+    location = "preprocessor 1/1",
+    type = "error",
+    note = "testing error"
+  )
+  expect_identical(res_fit$.notes[[1]], exp)
+  expect_identical(res_fit$.notes[[2]], exp)
+
+  expect_true(
+    all(vapply(res_fit$.metrics, NROW, integer(1)) == 0)
+  )
+  rm(list = "prep.step_logging_helper", envir = .GlobalEnv)
+  rm(list = "bake.step_logging_helper", envir = .GlobalEnv)
+})
+
+test_that("capturing warning correctly in notes", {
+  assign("prep.step_logging_helper", prep.step_logging_helper, envir = .GlobalEnv)
+  assign("bake.step_logging_helper", bake.step_logging_helper, envir = .GlobalEnv)
+  
+  ames <- modeldata::ames[, c(72, 40:45)]
+
+  set.seed(1234)
+  folds <- rsample::vfold_cv(ames, 2)
+
+  rec_spec <- recipe(Sale_Price ~ ., ames) %>%
+    step_logging_helper(type = "warning")
+  mod_spec <- parsnip::nearest_neighbor(
+    "regression",
+    "kknn",
+    dist_power = tune()
+  )
+
+  wf_spec <- workflow(rec_spec, mod_spec)
+  res_fit <- melodie_grid(
+    wf_spec,
+    folds,
+    grid = 2,
+    control = control_grid(allow_par = FALSE)
+  )
+
+  exp <- tibble::tibble(
+    location = "preprocessor 1/1",
+    type = "warning",
+    note = "testing warning"
+  )
+  expect_identical(res_fit$.notes[[1]], exp)
+  expect_identical(res_fit$.notes[[2]], exp)
+
+  expect_true(
+    all(vapply(res_fit$.metrics, NROW, integer(1)) > 0)
+  )
+  rm(list = "prep.step_logging_helper", envir = .GlobalEnv)
+  rm(list = "bake.step_logging_helper", envir = .GlobalEnv)
+})
+
+test_that("doesn't capturing message in notes", {
+  assign("prep.step_logging_helper", prep.step_logging_helper, envir = .GlobalEnv)
+  assign("bake.step_logging_helper", bake.step_logging_helper, envir = .GlobalEnv)
+  
+  ames <- modeldata::ames[, c(72, 40:45)]
+
+  set.seed(1234)
+  folds <- rsample::vfold_cv(ames, 2)
+
+  rec_spec <- recipe(Sale_Price ~ ., ames) %>%
+    step_logging_helper(type = "message")
+  mod_spec <- parsnip::nearest_neighbor(
+    "regression",
+    "kknn",
+    dist_power = tune()
+  )
+
+  wf_spec <- workflow(rec_spec, mod_spec)
+
+  expect_snapshot(
+    res_fit <- tune_grid(
+      wf_spec,
+      folds,
+      grid = 2,
+      control = control_grid(allow_par = FALSE)
+    )
+  )
+
+  exp <- tibble::tibble(
+    location = character(0), 
+    type = character(0), 
+    note = character(0)
+  )
+
+  expect_identical(res_fit$.notes[[1]], exp)
+  expect_identical(res_fit$.notes[[2]], exp)
+
+  expect_true(
+    all(vapply(res_fit$.metrics, NROW, integer(1)) > 0)
+  )
+  rm(list = "prep.step_logging_helper", envir = .GlobalEnv)
+  rm(list = "bake.step_logging_helper", envir = .GlobalEnv)
+})


### PR DESCRIPTION
This PR makes it so notes are created and returned from `loopy()`.

it DOESN'T emit the errors/warnings, just collects them for output.

the parsing of the messages is also barebones right now as i will get to it once i get to the emitting stage as it might need to formatting in a particular way for [progressr](https://cran.r-project.org/web/packages/progressr/vignettes/progressr-intro.html)

in particular i didn't go with the `<<-` approach that was used in old tune. right now i like it as it is more explicit what happens.